### PR TITLE
Move to python 3, add option to modify Catalog.xml

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,14 @@
 # Dell Update Mirror #
-A script written to provide a local mirror copy of the Dell Updates for specific server models, I have only tested and used the mirror that is produced with the Dell Server Lifecycle Controller.
+A script written to provide a local mirror copy of the Dell Updates for
+specific server models, I have only tested and used the mirror that is produced
+with the Dell Server Lifecycle Controller.
 
 ```bash
-python ./dellmirror.py --help
+python3 ./dellmirror.py --help
 
 usage: dellmirror.py [-h] --server MODELS --destination WEBROOT [--getcatalog]
-                     [--onlyfirmware] [--threads THREADS]
+                     [--remove-catalog-location] [--onlyfirmware]
+                     [--threads THREADS]
 
 optional arguments:
   -h, --help            show this help message and exit
@@ -16,6 +19,11 @@ optional arguments:
                         webroot for the mirror
   --getcatalog          Forces an update to the current Catalog file for the
                         mirror
+  --remove-catalog-location
+                        Removes the attributes of the Catalog.xml which is
+                        hardcoed to "https://downloads.dell.com/". If these
+                        remain, some systems fetches files from there instead
+                        of the mirror location.
   --onlyfirmware        Only downloads files with a BIOS or Firmware category
                         (useful for Lifecycle Controller based updates)
   --threads THREADS     Number of simultaneous threads to download (enter a
@@ -27,13 +35,44 @@ optional arguments:
 ### To download all update files for a set of server models ###
 
 ```bash
-python ./dellmirror.py --server "R420,R720,R630,R730,R730xd" --destination /var/www/html
+python3 ./dellmirror.py --server "R420,R720,R630,R730,R730xd" --destination /var/www/html
 ```
 
 ### To download only Firmware or BIOS files for a set of server models ###
 
 ```bash
-python ./dellmirror.py --server "R420,R720,R630,R730,R730xd" --destination /var/www/html --onlyfirmware
+python3 ./dellmirror.py --server "R420,R720,R630,R730,R730xd" --destination /var/www/html --onlyfirmware
 ```
 
-#### Note: a single model can be specified if required (ie "R730") ####
+_Note: a single model can be specified if required (ie "R730")_
+
+## About Catalog.xml ##
+
+This script downloads `Catalog.xml.gz` from Dell, this file contains
+
+When updating machines via HTTP from iDrac or racadm. For example, by specify
+the URL to "dell.foo.bar", and the idrac will happily pull the Catalog.xml file
+from there, and present any updates it finds that is applicable for the server.
+But after clicking "install" any downloads will fail with the following error:
+`RED006: Unable to download Update Package.`.  The `<Manifest>` declaration in
+the catalog contains this by default:
+
+```
+<Manifest baseLocation="downloads.dell.com" baseLocationAccessProtocols="HTTPS"
+```
+
+This causes idrac to try to download the packages from `downloads.dell.com`,
+using the `HTTPS` protocol, but this fails since we requested HTTP in idrac.
+If one specifies HTTPS-method in idrac and still enter the "dell.foo.bar" (our
+internal mirror host), the update works, but packages are actually downloaded
+from downloads.dell.com, not our mirror.
+
+The fix for us is to either update the baseLocation and
+baseLocationAccessProtocol to match our settings, or to remove both properties.
+Both paths work so far it seems.  Currently the script only have functionality
+to remove the attributes, not modify them.
+
+Use the `--remove-catalog-location` option to remove those attributes. This
+unfortunately also has the effect that all `CDATA`-content is converted to
+regular strings, ElementTree doesn't seem to be able to retain the `CDATA` when
+writing the file.

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ optional arguments:
                         mirror
   --remove-catalog-location
                         Removes the attributes of the Catalog.xml which is
-                        hardcoed to "https://downloads.dell.com/". If these
+                        hardcoded to "https://downloads.dell.com/". If these
                         remain, some systems fetches files from there instead
                         of the mirror location.
   --onlyfirmware        Only downloads files with a BIOS or Firmware category

--- a/dellmirror.py
+++ b/dellmirror.py
@@ -108,7 +108,7 @@ if not os.path.exists(unzippedCatalog):
 
 if args.getcatalog or downloadCatalog:
     fileToDownload = '{0}/Catalog/Catalog.xml.gz'.format(args.destination)
-    url = 'http://ftp.dell.com/Catalog/Catalog.xml.gz'
+    url = 'https://downloads.dell.com/Catalog/Catalog.xml.gz'
 
     dirname = os.path.dirname(fileToDownload)
     if not os.path.exists(dirname):
@@ -196,7 +196,7 @@ for sb in e.findall('SoftwareBundle'):
                         printColour('\n')
 
                         if needDownload:
-                            url = 'http://ftp.dell.com/{0}'.format(driverpath)
+                            url = 'https://downloads.dell.com/{0}'.format(driverpath)
 
                             dirname = os.path.dirname(fileToDownload)
                             if not os.path.exists(dirname):

--- a/dellmirror.py
+++ b/dellmirror.py
@@ -15,7 +15,7 @@ parser = argparse.ArgumentParser()
 parser.add_argument('--server', help='Comma separated list of Models to download files for (eg. "R620,R720,R730,R730xd")', required=True, metavar='MODELS')
 parser.add_argument('--destination', help='Destination folder for mirrored data, needs to be the webroot for the mirror', required=True, metavar='WEBROOT')
 parser.add_argument('--getcatalog', help='Forces an update to the current Catalog file for the mirror', action='store_true')
-parser.add_argument('--remove-catalog-location', help='Removes the attributes of the Catalog.xml which is hardcoed to "https://downloads.dell.com/". If these remain, some systems fetches files from there instead of the mirror location.', action='store_true')
+parser.add_argument('--remove-catalog-location', help='Removes the attributes of the Catalog.xml which is hardcoded to "https://downloads.dell.com/". If these remain, some systems fetches files from there instead of the mirror location.', action='store_true')
 parser.add_argument('--onlyfirmware', help='Only downloads files with a BIOS or Firmware category (useful for Lifecycle Controller based updates)', action='store_true')
 parser.add_argument('--threads', default=8, type=int, help='Number of simultaneous threads to download (enter a number only)')
 


### PR DESCRIPTION
Move script to python 3, since python 2 is end of life. Only small
modifications required for this.
 * `Queue` module renamed to `queue`.
 * `threading.isAlive()` renamed to `threading.is_alive()`.
 * replaced subprocess/md5 with `hashlib` routine instead. Not strictly
necessary for the python3 migration, but had to do with
string encoding mess from subprocess-output.

Options to change Catalog.xml was added to remove the occurance of
`baseLocation`and `baseLocationAccessProtocols` which are present in the
original Catalog from dell. These two variables forces
lifecyclecontroller / idrac to fetch updates from the location specified
there using that protocol, instead of the mirror this script created. As
described in https://github.com/littlejon/dell-update-mirror/issues/1